### PR TITLE
fix: 优化终端交互中文文案

### DIFF
--- a/spec-dashboard/package.json
+++ b/spec-dashboard/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --test src/i18n/*.test.mjs",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/spec-dashboard/package.json
+++ b/spec-dashboard/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "node --test src/i18n/*.test.mjs",
+    "test": "node --test src/*.test.mjs src/i18n/*.test.mjs",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/spec-dashboard/src/Dashboard.jsx
+++ b/spec-dashboard/src/Dashboard.jsx
@@ -17,10 +17,11 @@ import { useResizable } from './useResizable.js'
 import { layout, X_GAP, Y_GAP } from './data.js'
 import { createMomentumScroll } from './scroll.js'
 import { cycleNext } from './cycle.js'
-import { firesKey } from './bindings.js'
+import { firesKey, keysOf } from './bindings.js'
 import { returnFocus } from './focus.js'
 import { labelColor } from './color.js'
 import { sessionHeadline } from './session.js'
+import { lockCycleKeyLabels, showLockCycleKeys } from './lockHint.js'
 import { useT } from './i18n/index.jsx'
 
 // code-split the heavy leaves off the desktop entry chunk: the session console drags in xterm (+addons),
@@ -114,6 +115,7 @@ function Dashboard({ specs, sessions, reload, project, issuesData, reloadIssues 
     [specs, highlightId],
   )
   const cycleNodes = useMemo(() => (highlightId ? lockedNodes : overlayNodes), [highlightId, lockedNodes, overlayNodes])
+  const lockCycleKeys = lockCycleKeyLabels(keysOf)
 
   const liveEditorsOf = useCallback(
     (node) => (node ? sessions.filter((s) => s.ops?.some((op) => op.nodeId === node.id)) : []),
@@ -555,7 +557,13 @@ function Dashboard({ specs, sessions, reload, project, issuesData, reloadIssues 
             <span className="lock-hint-lead"><LockGlyph /> {sessionHeadline(lockedSession)}</span>
             {lockedNodes.length ? (
               <span className="lock-hint-body">
-                {t('lockHint.cycleBefore')}<kbd>o</kbd><kbd>O</kbd>{t('lockHint.cycleAfter', { n: lockedNodes.length })}
+                {showLockCycleKeys(lockedNodes.length) ? (
+                  <>
+                    {t('lockHint.cycleBefore')}<kbd>{lockCycleKeys.next}</kbd>{t('lockHint.cycleNext')}
+                    <span className="lock-hint-sep"> / </span>
+                    <kbd>{lockCycleKeys.prev}</kbd>{t('lockHint.cyclePrev')}{t('lockHint.cycleAfter', { n: lockedNodes.length })}
+                  </>
+                ) : t('lockHint.singleChanged')}
               </span>
             ) : (
               <span className="lock-hint-body">{t('lockHint.empty')}</span>

--- a/spec-dashboard/src/i18n/en.js
+++ b/spec-dashboard/src/i18n/en.js
@@ -202,7 +202,10 @@ export default {
   // the user the key to walk that session's changed nodes — or that the session has none to show.
   lockHint: {
     cycleBefore: 'press ',
-    cycleAfter: ({ n }) => ` to cycle its ${n} changed node${n === 1 ? '' : 's'}`,
+    cycleNext: ' next',
+    cyclePrev: ' previous',
+    cycleAfter: ({ n }) => ` through this session's ${n} changed nodes`,
+    singleChanged: 'this session changed 1 node',
     empty: 'this session has no pending spec changes',
     release: 'release',
     releaseTitle: 'release the lock (or click the session again)',

--- a/spec-dashboard/src/i18n/zh.js
+++ b/spec-dashboard/src/i18n/zh.js
@@ -366,8 +366,8 @@ export default {
     launcherLabel: '启动器',
     tabTerminal: '终端',
     tabEval: '评测',
-    typeBtn: '打字',
-    typeTitle: '打字模式——把原始按键（含 ⌃/⌥/⌘ 组合键）直接敲进智能体的终端（⌥/⌘+I）',
+    typeBtn: '终端交互',
+    typeTitle: '终端交互模式——把原始按键（含 ⌃/⌥/⌘ 组合键）直接发送到智能体的终端（⌥/⌘+I）',
     relaunch: '重新启动',
     merge: '合并',
     relaunchResume: '⏵ 重新启动并恢复',
@@ -376,9 +376,9 @@ export default {
     offlineMsg: '⏻ 离线——此工作树没有活动进程。',
     offlineSubBefore: '工作树及其会话 ',
     offlineSubAfter: ' 仍然完好。重新启动以恢复同一对话。',
-    typeInd: '⌨ 打字模式',
-    typeHelp: '按键（含 ⌃/⌥/⌘ 组合键）将发送给会话 · ⌥/⌘+I、Esc-Esc 或点击退出',
-    typeExit: '点击退出打字模式',
+    typeInd: '⌨ 终端交互模式',
+    typeHelp: '按键（含 ⌃/⌥/⌘ 组合键）将发送到终端 · ⌥/⌘+I、Esc-Esc 或点击退出',
+    typeExit: '点击退出终端交互模式',
     msgOffline: '重新启动以向此会话发送消息',
     msgPlaceholder: '向此会话发送消息 · ⏎ 发送',
     msgError: '⚠ 未送达 — 重试',
@@ -387,7 +387,7 @@ export default {
     // 面板命令 —— ❯ 输入框在本地执行（不发送给智能体）的 `/` 命令，每条都是某个顶栏按钮的“打字版”。
     // `*Desc` 是 `/` 菜单行的说明；`*Title` 是按钮的悬停提示。
     cmd: {
-      typeDesc: '打字模式 —— 把原始按键直接敲进智能体的终端',
+      typeDesc: '终端交互模式 —— 把原始按键直接发送到智能体的终端',
       evalDesc: '切换到此会话的评测页 —— yatsu 证据、改动、合并门禁',
       mergeTitle: '将此会话合并到 main',
       mergeDesc: '将此会话合并到 main',

--- a/spec-dashboard/src/i18n/zh.js
+++ b/spec-dashboard/src/i18n/zh.js
@@ -197,7 +197,10 @@ export default {
 
   lockHint: {
     cycleBefore: '按 ',
-    cycleAfter: ({ n }) => ` 循环浏览它更改的 ${n} 个节点`,
+    cycleNext: ' 下一个',
+    cyclePrev: ' 上一个',
+    cycleAfter: ({ n }) => `，浏览此会话更改的 ${n} 个节点`,
+    singleChanged: '此会话更改了 1 个节点',
     empty: '此会话没有待处理的规格更改',
     release: '解除',
     releaseTitle: '解除锁定（或再次单击该会话）',

--- a/spec-dashboard/src/i18n/zh.test.mjs
+++ b/spec-dashboard/src/i18n/zh.test.mjs
@@ -10,3 +10,10 @@ test('terminal raw-key mode is labeled as terminal interaction in Chinese', () =
   assert.equal(zh.session.typeExit, '点击退出终端交互模式')
   assert.match(zh.session.cmd.typeDesc, /^终端交互模式/)
 })
+
+test('locked session hint describes changed-node browsing precisely in Chinese', () => {
+  assert.equal(zh.lockHint.singleChanged, '此会话更改了 1 个节点')
+  assert.equal(zh.lockHint.cycleNext, ' 下一个')
+  assert.equal(zh.lockHint.cyclePrev, ' 上一个')
+  assert.equal(zh.lockHint.cycleAfter({ n: 2 }), '，浏览此会话更改的 2 个节点')
+})

--- a/spec-dashboard/src/i18n/zh.test.mjs
+++ b/spec-dashboard/src/i18n/zh.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import zh from './zh.js'
+
+test('terminal raw-key mode is labeled as terminal interaction in Chinese', () => {
+  assert.equal(zh.session.typeBtn, '终端交互')
+  assert.match(zh.session.typeTitle, /^终端交互模式/)
+  assert.equal(zh.session.typeInd, '⌨ 终端交互模式')
+  assert.match(zh.session.typeHelp, /发送到终端/)
+  assert.equal(zh.session.typeExit, '点击退出终端交互模式')
+  assert.match(zh.session.cmd.typeDesc, /^终端交互模式/)
+})

--- a/spec-dashboard/src/keymap.js
+++ b/spec-dashboard/src/keymap.js
@@ -46,4 +46,4 @@ export const ACT = [
 
 // KeyboardEvent.key → display glyph for the keymap chips (shared by the legend and the settings editor).
 export const KEY_GLYPH = { ArrowUp: '↑', ArrowDown: '↓', ArrowLeft: '←', ArrowRight: '→', Enter: '⏎', Escape: 'esc', ' ': '␣', '-': '−' }
-export const keyCap = (k) => KEY_GLYPH[k] || k
+export const keyCap = (k) => KEY_GLYPH[k] || (/^[A-Z]$/.test(k) ? `⇧ ${k}` : k)

--- a/spec-dashboard/src/lockHint.js
+++ b/spec-dashboard/src/lockHint.js
@@ -1,0 +1,12 @@
+import { keyCap } from './keymap.js'
+
+export function showLockCycleKeys(count) {
+  return count > 1
+}
+
+export function lockCycleKeyLabels(keysFor) {
+  return {
+    next: keyCap((keysFor('board.cycle') || [])[0] || 'o'),
+    prev: keyCap((keysFor('board.cycleRev') || [])[0] || 'O'),
+  }
+}

--- a/spec-dashboard/src/lockHint.test.mjs
+++ b/spec-dashboard/src/lockHint.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { lockCycleKeyLabels, showLockCycleKeys } from './lockHint.js'
+
+test('lock hint hides cycle keys when there is only one changed node', () => {
+  assert.equal(showLockCycleKeys(0), false)
+  assert.equal(showLockCycleKeys(1), false)
+  assert.equal(showLockCycleKeys(2), true)
+})
+
+test('lock hint labels uppercase reverse key as a shift chord', () => {
+  const keysFor = (id) => id === 'board.cycle' ? ['o'] : ['O']
+
+  assert.deepEqual(lockCycleKeyLabels(keysFor), {
+    next: 'o',
+    prev: '⇧ O',
+  })
+})

--- a/spec-dashboard/src/styles.css
+++ b/spec-dashboard/src/styles.css
@@ -163,6 +163,7 @@ body.is-resizing, body.is-resizing * { cursor: col-resize !important; user-selec
   border: 1px solid var(--line); border-radius: 3px; padding: 0 5px; margin: 0 1px;
   color: var(--blue); font-family: var(--mono); font-size: 11px;
 }
+.lock-hint-sep { color: var(--muted); }
 .lock-hint-release {
   flex: none; cursor: pointer; padding: 1px 8px;
   background: var(--paper); border: 1px solid var(--line); border-radius: 4px;


### PR DESCRIPTION
## 变更
- 将终端右上角 type mode 的中文文案从「打字」改为「终端交互」。
- 同步更新进入模式后的提示、退出提示和命令说明。
- 优化锁定 session 横幅：只有 1 个更改节点时不再展示循环按键，改为直接说明「此会话更改了 1 个节点」。
- 多个更改节点时明确展示正向 / 反向操作：`o` 下一个，`⇧ O` 上一个，避免大写 `O` 被看成数字 `0`。
- 为中文 i18n 与锁定横幅按键展示增加回归测试，并扩展 dashboard 的 `npm test` 脚本。

## 验证
- `cd spec-dashboard && npm test`
- `cd spec-dashboard && npm run build`