### PR TITLE
fix: protect frozen legacy mark-active hooks in 0.5.9

### DIFF
--- a/.spec/spexcode/spec-cli/cli-surface/spec.md
+++ b/.spec/spexcode/spec-cli/cli-surface/spec.md
@@ -42,7 +42,9 @@ only lifecycle verbs that release session resources.
 `spex session quarantine <ID> --adapter <harness> [--thread <native-id>] --tmux <id> --worktree <absent-path>
 --branch <absent-branch>` is the separate record-integrity control for an unreadable row. It moves no worktree,
 branch, process, or readable lifecycle record: the backend consumes its exact absence witness before it moves
-opaque bytes out of active projection. Both it and `--restore` require the original exact id rather than a
+opaque bytes out of active projection. Its optional `--thread` is an adapter-native conversation id, not the
+SpexCode session id; callers omit it when the named adapter has no native thread to archive, including Claude.
+Both it and `--restore` require the original exact id rather than a
 selector, because corrupt rows never belong to selector enumeration.
 
 Project session maintenance stays inside the six-noun grammar as one scoped porcelain verb:

--- a/.spec/spexcode/spec-cli/sessions/injected-context/hook-dispatch/dispatcher-runtime/spec.md
+++ b/.spec/spexcode/spec-cli/sessions/injected-context/hook-dispatch/dispatcher-runtime/spec.md
@@ -36,3 +36,21 @@ stdout, or event side effect. A missing manifest remains a no-op because there i
 Outside maintenance, all matching handlers run under the one live ticket and preserve the existing deterministic
 order, stdout concatenation, blocking declaration, and Codex stderr reason translation. Non-hook reads are not
 this runtime's responsibility and remain open.
+
+### Known-corrupt mark-active compatibility
+
+The original shipped `core/mark-active` script treated its note as text safe to substitute into JSON. Its own
+comment asserted that a note never contains a double quote, but neither the declaration nor the harness payload
+enforced that assertion; a quote therefore closed the JSON string and made a live record unreadable. Existing
+projects track their seeded `.plugins` source, and `spex materialize` deliberately renders that source rather
+than overwriting it. Updating the global package alone would otherwise leave a frozen worktree executing the
+bad script.
+
+The dispatcher has one narrow, package-owned compatibility route: when the manifest names the standard
+`.spec/project/.plugins/core/mark-active/mark-active.sh` path **and that file byte-compares equal to the
+identified vulnerable shipped revision**, it executes the package's current structured `mark-active` implementation
+instead. It does not edit the project file, its manifest, or any session record before that implementation runs.
+Any byte difference, including a project customization, executes the project script exactly as the manifest
+requested. This is an emergency execution override, not a plugin updater: a project moves its tracked source to
+the current template only in its own reviewed maintenance change. The compatibility entry remains only for the
+identified broken revision; a new project hook never enters this route.

--- a/.spec/spexcode/spec-cli/sessions/injected-context/hook-dispatch/legacy-mark-active-compat/spec.md
+++ b/.spec/spexcode/spec-cli/sessions/injected-context/hook-dispatch/legacy-mark-active-compat/spec.md
@@ -1,0 +1,20 @@
+---
+title: legacy mark-active compatibility
+status: active
+hue: 280
+desc: The byte-exact fixture that identifies the one shipped mark-active revision which composed arbitrary note prose into session.json.
+code:
+  - spec-cli/hooks/compat/mark-active-sed-v0.fixture
+related:
+  - spec-cli/hooks/dispatch.sh
+  - spec-cli/src/hook-dispatch.test.ts
+---
+
+# legacy mark-active compatibility
+
+This node owns the one read-only fixture for the 0.5.2 default `mark-active` script. The bytes are an
+identity, not an executable fallback: `dispatch.sh` compares the project handler against them and, only on an
+exact match at the standard core path, runs the package's structured implementation instead. The fixture stays
+byte-for-byte equal to the faulty shipped revision, including its unenforced “note never contains quote”
+assumption; changing it would silently widen or disable the compatibility decision. The runtime policy and its
+no-tracked-write guarantee are owned by [[dispatcher-runtime]].

--- a/.spec/spexcode/spec-cli/sessions/lifecycle/launch/session-new-monitor-hint/spec.md
+++ b/.spec/spexcode/spec-cli/sessions/lifecycle/launch/session-new-monitor-hint/spec.md
@@ -32,7 +32,8 @@ new primitive.
 verb's syntax, output, side effects and blocking behaviour. It does not prescribe an orchestration workflow.
 The full `spex session` / `spex help session` drawer remains intact. Both views
 are rendered from one shared session-help definition, so wait's edge semantics, watch's never-exit warning,
-send's raw-key warning, quarantine's exact-witness/restore-id rule, selector grammar, and project-bound write warning cannot drift between a drawer
+send's raw-key warning, quarantine's exact-witness/restore-id rule (including that `--thread` is an adapter-native
+conversation id rather than the SpexCode session id, and is omitted for Claude), selector grammar, and project-bound write warning cannot drift between a drawer
 manual and copied verb manuals. Existing session verbs and spellings keep their behaviour; this is a help
 projection change only.
 

--- a/.spec/spexcode/spec-cli/sessions/lifecycle/state/spec.md
+++ b/.spec/spexcode/spec-cli/sessions/lifecycle/state/spec.md
@@ -213,6 +213,11 @@ board lifecycle. During draining/active maintenance every manifest handler is wi
 `maintenance_active` and zero handler side effect. Only non-hook reads remain open. Once admitted, one dispatcher
 ticket spans the complete ordered handler run and is released on every exit.
 
+For the known pre-structured `mark-active` source bytes still tracked by existing projects, the dispatcher
+executes the package-owned structured implementation without rewriting the tracked hook; that bounded compatibility
+is specified by [[dispatcher-runtime]]. Thus a package upgrade protects frozen worktrees immediately, while a
+project's eventual source migration remains an explicit reviewed change rather than a hidden materialize effect.
+
 - **`UserPromptSubmit` + `PreToolUse` → one `mark-active` hook**: it writes **`asking`** on an
   **AskUserQuestion** (the question → the note), else **`active`** — the freshness signal that also flips
   a stale `idle`/`asking` back the moment work resumes.

--- a/.spec/spexcode/spec-cli/sessions/sessions-core/spec.md
+++ b/.spec/spexcode/spec-cli/sessions/sessions-core/spec.md
@@ -135,7 +135,9 @@ the harness can recognize is the harness's to declare ([[harness-adapter]]).
 
 An unreadable governed record has one separate recovery control: **quarantine** is neither `close` nor a
 repair. The caller supplies the exact former adapter/thread (or explicitly no native thread), tmux session,
-worktree path, and branch it extracted from the opaque incident. The shared layer then re-proves, at execution
+worktree path, and branch it extracted from the opaque incident. The thread field is an adapter-native
+conversation id, never the SpexCode session id: CLI omission explicitly sends no native thread, which is the
+required witness for an adapter such as Claude that has none to archive. The shared layer then re-proves, at execution
 time, that the session's registered leaf process is absent, that exact tmux session/worktree/branch are absent,
 and that the named adapter is healthy. A named native thread must either be absent, or be an exactly-unowned,
 idle, descendant-free native thread that its own adapter archives and re-censuses as unloaded; every live,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spexcode",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spexcode",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.13.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spexcode",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "type": "module",
   "description": "SpexCode — a spec-driven, self-developing dev tool. The `spex` CLI + spec server reads the .spec tree and its git history, and serves the dashboard.",
   "license": "MIT",

--- a/spec-cli/hooks/compat/mark-active-sed-v0.fixture
+++ b/spec-cli/hooks/compat/mark-active-sed-v0.fixture
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# @@@ mark-active - the SINGLE freshness hook, wired to BOTH UserPromptSubmit and PreToolUse. It branches
+# on ONE structured signal read straight from the hook payload (stdin JSON), so the state is HARD — never
+# text-sniffed from the TUI:
+#   the agent is pausing to ask the HUMAN (hp_is_ask) → status: asking, with the question text as the note
+#                                  (the deterministic capture of a question).
+#   any other tool, or a prompt submit → the agent is working → status: active (drop a now-stale proposal/note).
+# WHAT counts as "asking" is the [[harness-adapter]]'s call (Claude: the AskUserQuestion tool; Codex: the
+# request_user_input tool) — read via hp_is_ask, so this hook never names a harness tool.
+# Fires BEFORE the tool runs, so a `spex session done` declaration (itself a tool) lands AFTER this and wins;
+# the next real tool flips back to active, forcing a fresh Stop-gate declaration. Pure shell (no node/tsx) so
+# it stays cheap on every tool call — it value-replaces status/proposal/note in session.json with sed, never jq.
+# @@@ global store - state lives NOT in the worktree but in the per-session GLOBAL record session.json, keyed
+# by the harness session_id, grouped per-project (see hp_store_dir). GATED on `governed`: a user-self-launched
+# (non-governed) session has no board to feed, so this no-ops on it. cwd = the session worktree.
+. "${SPEXCODE_HARNESS_LIB:?harness.sh not exported by dispatch.sh}"
+payload=$(cat 2>/dev/null)
+sid=$(hp_session_id "$payload"); [ -n "$sid" ] || exit 0
+sdir=$(hp_store_dir "$sid") || exit 0
+rec="$sdir/session.json"
+# board-lifecycle gate: only a GOVERNED (dashboard-launched) session has a board state to maintain.
+grep -q '"governed"[[:space:]]*:[[:space:]]*true' "$rec" 2>/dev/null || exit 0
+
+jget() { sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$rec" 2>/dev/null | head -1; }
+
+if [ -n "$(hp_is_ask "$payload")" ]; then
+  status=asking
+  note=$(hp_ask_note "$payload")   # first question's text → the note (best-effort)
+else
+  status=active
+  note=
+fi
+
+# cheap path: already active with nothing stale to clear → no-op (the common every-tool case).
+[ "$status" = active ] && [ "$(jget status)" = active ] && [ -z "$(jget proposal)" ] && [ -z "$(jget note)" ] && exit 0
+
+# value-replace status + clear proposal + (re)set note, in place. The record is written one-field-per-line
+# with these keys ALWAYS present (sessions.ts writeRecord), so each is a single value substitution — no key
+# add/remove, no JSON parser. Escape \ / & in the note for the sed REPLACEMENT (the note never contains ").
+note_esc=$(printf '%s' "$note" | sed 's/[\\/&]/\\&/g')
+tmp=$(mktemp) || exit 0
+sed -e "s/\(\"status\"[[:space:]]*:[[:space:]]*\)\"[^\"]*\"/\1\"$status\"/" \
+    -e "s/\(\"proposal\"[[:space:]]*:[[:space:]]*\)\"[^\"]*\"/\1\"\"/" \
+    -e "s/\(\"note\"[[:space:]]*:[[:space:]]*\)\"[^\"]*\"/\1\"$note_esc\"/" \
+    "$rec" > "$tmp" && mv "$tmp" "$rec"
+exit 0

--- a/spec-cli/hooks/dispatch.sh
+++ b/spec-cli/hooks/dispatch.sh
@@ -28,12 +28,14 @@ event="${1:?usage: dispatch.sh <harness> <Event>}"
 export SPEXCODE_HARNESS="$harness"
 # the harness.sh path (the adapter's shell mirror) — sibling of this script; hook handlers source it, and we
 # source it here too for hp_runtime_dir (the per-project store dir).
-export SPEXCODE_HARNESS_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/harness.sh"
+hook_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tool_root="$(cd "$hook_root/.." && pwd)"
+export SPEXCODE_HARNESS_LIB="$hook_root/harness.sh"
 . "$SPEXCODE_HARNESS_LIB"
 if [ -n "${SPEX:-}" ]; then
   read -r -a spex_cmd <<< "$SPEX"
 else
-  spex_cmd=("$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/bin/spex.mjs")
+  spex_cmd=("$tool_root/bin/spex.mjs")
 fi
 proj="${CLAUDE_PROJECT_DIR:-$PWD}"
 # the manifest lives in THIS tree's materialize slot of the GLOBAL per-project store (mirrors layout.treeSlotDir),
@@ -90,7 +92,15 @@ rc=0
 # manifest line: event<TAB>order<TAB>block<TAB>script  (pre-sorted by event,order,script)
 while IFS=$'\t' read -r ev order block script; do
   [ "$ev" = "$event" ] || continue
-  out="$(printf '%s' "$input" | bash "$proj/$script" 2>"$err")"; code=$?
+  handler="$proj/$script"
+  # A seeded core hook is tracked project source, so package replacement cannot safely overwrite it. These
+  # byte-exact default revision composes an ask note into JSON with sed; route only it to the package
+  # implementation. `cmp` makes a user-modified hook ineligible without a platform-specific hash utility.
+  if [ "$script" = '.spec/project/.plugins/core/mark-active/mark-active.sh' ] &&
+    cmp -s "$handler" "$hook_root/compat/mark-active-sed-v0.fixture"; then
+    handler="$tool_root/templates/spec/project/.plugins/core/mark-active/mark-active.sh"
+  fi
+  out="$(printf '%s' "$input" | bash "$handler" 2>"$err")"; code=$?
   [ -n "$out" ] && printf '%s' "$out"
   if [ "$block" = "true" ] && { [ "$code" = "2" ] || printf '%s' "$out" | grep -q '"decision"[[:space:]]*:[[:space:]]*"block"'; }; then
     cat "$err" >&2

--- a/spec-cli/package-lock.json
+++ b/spec-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spexcode/spec-cli",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spexcode/spec-cli",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@hono/node-ws": "^1.0.4",

--- a/spec-cli/package.json
+++ b/spec-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spexcode/spec-cli",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "private": true,
   "type": "module",
   "description": "SpexCode CLI + server — INTERNAL monorepo package. The published npm unit is `spexcode` at the repo ROOT (it ships this package's src plus the sibling spec-eval/spec-forge src and the dashboard dist, preserving the layout so the cross-package ../../spec-* imports resolve). See .spec/spexcode/spec-cli/packaging.",

--- a/spec-cli/src/cli.ts
+++ b/spec-cli/src/cli.ts
@@ -875,7 +875,7 @@ if (cmd === 'serve') {
       console.log(`closed ${full}`)
     } else if (sub === 'quarantine') {
       rejectUnknownFlags('spex session quarantine', 4, ['adapter', 'thread', 'tmux', 'worktree', 'branch', 'restore', 'api', 'port'])
-      if (!id) { console.error('usage: spex session quarantine <ID> --adapter <harness> [--thread <native-id>] --tmux <session-id> --worktree <absent-path> --branch <absent-branch>') ; process.exit(2) }
+      if (!id) { console.error('usage: spex session quarantine <ID> --adapter <harness> [--thread <native-id>] --tmux <session-id> --worktree <absent-path> --branch <absent-branch> (--thread is adapter-native; omit it for Claude)') ; process.exit(2) }
       if (has('restore')) {
         // Quarantine addresses an unreadable row which selector resolution intentionally excludes. Both the
         // move and its reverse therefore take the literal exact id, with the backend proving record state.
@@ -884,7 +884,7 @@ if (cmd === 'serve') {
       } else {
         const adapter = flag('adapter'), tmux = flag('tmux'), worktree = flag('worktree'), branch = flag('branch')
         if (!adapter || !tmux || !worktree || !branch) {
-          console.error('usage: spex session quarantine <ID> --adapter <harness> [--thread <native-id>] --tmux <session-id> --worktree <absent-path> --branch <absent-branch>')
+          console.error('usage: spex session quarantine <ID> --adapter <harness> [--thread <native-id>] --tmux <session-id> --worktree <absent-path> --branch <absent-branch> (--thread is adapter-native; omit it for Claude)')
           process.exit(2)
         }
         const quarantined = await c.clientQuarantine(id, { adapter, thread: flag('thread') ?? null, tmux, worktree, branch })

--- a/spec-cli/src/help.ts
+++ b/spec-cli/src/help.ts
@@ -71,7 +71,7 @@ provably cannot land.`, ['selector', 'project-bound']],
     unarchive: ['spex session unarchive <SEL>', 'Deprecated compatibility spelling: same behavior as resume, relaunching the same conversation.', ['selector']],
     close: ['spex session close <SEL>', 'Retire the session and its worktree.', ['selector', 'project-bound']],
     quarantine: ['spex session quarantine <ID> --adapter <harness> [--thread <native-id>] --tmux <id> --worktree <absent-path> --branch <absent-branch> [--restore]',
-      'Move only an unreadable record after the backend proves every named residue absent. Quarantine and --restore both require the original exact id because corrupt rows are outside selectors.', ['project-bound']],
+      'Move only an unreadable record after the backend proves every named residue absent. --thread is an adapter-native conversation id, never the SpexCode session id; omit it for Claude. Quarantine and --restore both require the original exact id because corrupt rows are outside selectors.', ['project-bound']],
     maintain: [[
       'spex session maintain --allow-stop <SEL> [--allow-resume <SEL>[:force]] … -- <command> [args…]',
       'spex session maintain --status',

--- a/spec-cli/src/hook-dispatch.test.ts
+++ b/spec-cli/src/hook-dispatch.test.ts
@@ -7,6 +7,7 @@ import { execFileSync, spawnSync } from 'node:child_process'
 
 const repo = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
 const dispatch = join(repo, 'spec-cli', 'hooks', 'dispatch.sh')
+const legacyMarkActive = join(repo, 'spec-cli', 'hooks', 'compat', 'mark-active-sed-v0.fixture')
 
 test('dispatch exits 2 when a blocking handler emits decision:block JSON', () => {
   const dir = mkdtempSync(join(tmpdir(), 'spex-dispatch-'))
@@ -24,6 +25,89 @@ test('dispatch exits 2 when a blocking handler emits decision:block JSON', () =>
   })
   assert.equal(r.status, 2)
   assert.match(r.stdout, /"decision":"block"/)
+})
+
+function legacyMarkActiveRig(custom = false) {
+  const dir = mkdtempSync(join(tmpdir(), 'spex-dispatch-legacy-mark-active-'))
+  const home = join(dir, 'home')
+  const runtime = join(home, 'projects', dir.replace(/[/.]/g, '-'))
+  const sid = 'legacy-mark-active'
+  const hook = join(dir, '.spec', 'project', '.plugins', 'core', 'mark-active', 'mark-active.sh')
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  mkdirSync(join(runtime, 'sessions', sid), { recursive: true })
+  mkdirSync(join(dir, '.spec', 'project', '.plugins', 'core', 'mark-active'), { recursive: true })
+  const legacy = readFileSync(legacyMarkActive, 'utf8')
+  writeFileSync(hook, custom ? legacy.replace('payload=$(cat 2>/dev/null)', 'printf "CUSTOM-HOOK\\n"\npayload=$(cat 2>/dev/null)') : legacy)
+  const manifest = join(runtime, 'hooks-manifest')
+  writeFileSync(manifest, 'PreToolUse\t10\tfalse\t.spec/project/.plugins/core/mark-active/mark-active.sh\n')
+  const rec = join(runtime, 'sessions', sid, 'session.json')
+  const writeRecord = (status = 'asking', proposal = 'old', note = 'old note') => writeFileSync(rec, JSON.stringify({
+    session_id: sid, governed: true, status, proposal, note,
+  }, null, 2))
+  const fire = (payload: unknown) => spawnSync('bash', [dispatch, 'claude', 'PreToolUse'], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      SPEX: join(repo, 'spec-cli', 'bin', 'spex.mjs'),
+      SPEXCODE_HOME: home,
+      SPEX_HOOK_MANIFEST: manifest,
+    },
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+  })
+  return { dir, home, hook, fire, rec, sid, writeRecord }
+}
+
+test('the exact legacy mark-active bytes corrupt a quoted note without the dispatcher override', () => {
+  const t = legacyMarkActiveRig()
+  t.writeRecord()
+  const r = spawnSync('bash', [t.hook], {
+    cwd: t.dir,
+    env: {
+      ...process.env,
+      SPEXCODE_HARNESS: 'claude',
+      SPEXCODE_HARNESS_LIB: join(repo, 'spec-cli', 'hooks', 'harness.sh'),
+      SPEXCODE_HOME: t.home,
+    },
+    input: JSON.stringify({
+      session_id: t.sid,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion',
+      tool_input: { question: 'GUGU_E2E_PORT="undefined"' },
+    }),
+    encoding: 'utf8',
+  })
+  assert.equal(r.status, 0, r.stderr)
+  assert.throws(() => JSON.parse(readFileSync(t.rec, 'utf8')))
+})
+
+test('dispatch routes the known legacy mark-active bytes through the structured writer', () => {
+  const t = legacyMarkActiveRig()
+  const note = 'GUGU_E2E_PORT="undefined"\n中文'
+  t.writeRecord()
+  const r = t.fire({
+    session_id: t.sid,
+    hook_event_name: 'PreToolUse',
+    tool_name: 'AskUserQuestion',
+    tool_input: { question: note },
+  })
+  assert.equal(r.status, 0, r.stderr)
+  const record = JSON.parse(readFileSync(t.rec, 'utf8'))
+  assert.equal(record.status, 'asking')
+  assert.equal(record.note, note)
+})
+
+test('dispatch does not override a byte-different mark-active customization', () => {
+  const t = legacyMarkActiveRig(true)
+  t.writeRecord()
+  const r = t.fire({
+    session_id: t.sid,
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command: 'true' },
+  })
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /CUSTOM-HOOK/)
 })
 
 type GateHarness = 'claude' | 'codex'

--- a/spec-cli/src/session-help-cli.test.ts
+++ b/spec-cli/src/session-help-cli.test.ts
@@ -16,6 +16,7 @@ test('session noun-verb help projects the exact verb from the shared drawer defi
     { verb: 'send', usage: 'Usage: spex session send <SEL> "<msg>"', behavior: /LAST RESORT:[\s\S]*UNSTABLE[\s\S]*SEL = session id[\s\S]*PROJECT-BOUND/ },
     { verb: 'wait', usage: 'Usage: spex session wait <SEL>', behavior: /EDGE-TRIGGERED[\s\S]*non-actionable status into an actionable one[\s\S]*SEL = session id/ },
     { verb: 'new', usage: 'Usage: spex session new "<prompt>"', behavior: /--prompt-file[\s\S]*successful receipt/ },
+    { verb: 'quarantine', usage: 'Usage: spex session quarantine <ID> --adapter <harness> [--thread <native-id>] --tmux <id> --worktree <absent-path> --branch <absent-branch> [--restore]', behavior: /--thread is an adapter-native conversation id, never the SpexCode session id; omit it for Claude/ },
   ]
   const outputs = cases.map(({ verb, usage, behavior }) => {
     const result = sessionHelp(verb)

--- a/spec-cli/src/sessions.test.ts
+++ b/spec-cli/src/sessions.test.ts
@@ -15,6 +15,8 @@ import { gitCommonDir, runtimeRoot, sessionRecordPath, sessionArtifactPath, sess
 import { readTimeline } from './session-timeline.js'
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+// This file mutates process-global harness and runtime state, so its fixtures must not overlap.
+const serial = { concurrency: false } as const
 const waitUntil = async (check: () => boolean, label: string, timeoutMs = 5000) => {
   const deadline = Date.now() + timeoutMs
   while (!check()) {
@@ -40,7 +42,7 @@ function assertIsolatedResumeStore(home: string, id: string): void {
   assert.ok(runtimeRoot().startsWith(`${home}/`), `resume fixture ${id} runtime root escaped isolated SPEXCODE_HOME`)
 }
 
-test('command presets compose once at the backend prompt boundary while unknown slash text passes through', () => {
+test('command presets compose once at the backend prompt boundary while unknown slash text passes through', serial, () => {
   const presets = [
     { name: 'tidy', body: 'Tidy these targets:\n\n{{targets}}\n\nSee [[links]] for context.' },
     { name: 'report', body: 'Report clearly.' },
@@ -65,7 +67,7 @@ test('command presets compose once at the backend prompt boundary while unknown 
   assert.equal(composeCommandPrompt('plain prompt', presets, specs), 'plain prompt')
 })
 
-test('the live rename command resolves to the self-rename prompt through the shared resolver', async () => {
+test('the live rename command resolves to the self-rename prompt through the shared resolver', serial, async () => {
   const prompt = await resolveCommandPrompt('/rename')
   assert.match(prompt, /Review the work this session is currently doing/)
   assert.match(prompt, /spex session rename \. "<name>"/)
@@ -73,7 +75,7 @@ test('the live rename command resolves to the self-rename prompt through the sha
   assert.equal(await resolveCommandPrompt('/not-a-preset'), '/not-a-preset')
 })
 
-test('session-create API rejects stale fields before entering the transaction', async () => {
+test('session-create API rejects stale fields before entering the transaction', serial, async () => {
   const stale = await sessionCreateRequest({ prompt: 'probe', launcher: 'claude', mode: 'headless' })
   assert.deepEqual(stale, { status: 400, error: 'unknown session-create field: mode' })
 
@@ -81,7 +83,7 @@ test('session-create API rejects stale fields before entering the transaction', 
   assert.deepEqual(removedNode, { status: 400, error: 'unknown session-create field: node' })
 })
 
-test('session creation exports only the bounded transaction owner', async () => {
+test('session creation exports only the bounded transaction owner', serial, async () => {
   const surface = await import('./sessions.js') as Record<string, unknown>
   assert.equal(surface.newSession, undefined)
   assert.equal(typeof surface.sessionCreateRequest, 'function')
@@ -90,7 +92,7 @@ test('session creation exports only the bounded transaction owner', async () => 
 // @@@ birth registration — EXECUTE a generated launch.sh whose agent command is a stub, and prove the wrapper
 // writes the REAL agent pid to agent.pid before exec (the anchor of the 100ms hot death tier), AND that an
 // argument carrying spaces/quotes/`$` survives the extra `sh -c` nesting un-double-expanded ([[state]]).
-test('launchScript registers the agent pid before exec and preserves tricky quoted args', async () => {
+test('launchScript registers the agent pid before exec and preserves tricky quoted args', serial, async () => {
   const prevHome = process.env.SPEXCODE_HOME
   const home = mkdtempSync(join(tmpdir(), 'spex-birth-'))
   process.env.SPEXCODE_HOME = home
@@ -161,7 +163,7 @@ exit 0
   chmodSync(tmux, 0o755)
 }
 
-test('maintenance resume holds its parent ticket after delegated spawn until adapter launch readiness', { timeout: 20_000, concurrency: false }, async () => {
+test('maintenance resume holds its parent ticket after delegated spawn until adapter launch readiness', { timeout: 20_000, ...serial }, async () => {
   const liveBefore = liveSessionsCensus()
   const previousHome = process.env.SPEXCODE_HOME
   const previousPath = process.env.PATH
@@ -297,7 +299,7 @@ touch ${JSON.stringify(consumed)}
   }
 })
 
-test('resume missing, failed, or invalidated readiness preserves the stopped offline record', { concurrency: false }, async (t) => {
+test('resume missing, failed, or invalidated readiness preserves the stopped offline record', serial, async (t) => {
   for (const outcome of ['missing', 'timeout', 'thrown', 'invalidated'] as const) await t.test(outcome, async () => {
     const liveBefore = liveSessionsCensus()
     const previousHome = process.env.SPEXCODE_HOME
@@ -358,7 +360,7 @@ test('resume missing, failed, or invalidated readiness preserves the stopped off
   })
 })
 
-test('a stale launch-readiness pending record recovers fail-closed before another launch attempt', { concurrency: false }, async () => {
+test('a stale launch-readiness pending record recovers fail-closed before another launch attempt', serial, async () => {
   const liveBefore = liveSessionsCensus()
   const previousHome = process.env.SPEXCODE_HOME
   const previousPath = process.env.PATH
@@ -421,7 +423,7 @@ test('a stale launch-readiness pending record recovers fail-closed before anothe
   }
 })
 
-test('stop revalidates the exact leaf after every shared guard before TERM and KILL', async () => {
+test('stop revalidates the exact leaf after every shared guard before TERM and KILL', serial, async () => {
   const previousHome = process.env.SPEXCODE_HOME
   const originalShared = claudeHarness.sharedRuntimes
   const originalCleanup = claudeHarness.cleanupRuntime
@@ -510,7 +512,7 @@ test('stop revalidates the exact leaf after every shared guard before TERM and K
   }
 })
 
-test('closing a proven-cold archive ignores unrelated shared refs but rejects target runtime ambiguity without signaling', async () => {
+test('closing a proven-cold archive ignores unrelated shared refs but rejects target runtime ambiguity without signaling', serial, async () => {
   const previousHome = process.env.SPEXCODE_HOME
   const originalShared = codexHarness.sharedRuntimes
   const originalColdPreflight = codexHarness.coldPreflight
@@ -587,7 +589,7 @@ test('closing a proven-cold archive ignores unrelated shared refs but rejects ta
   }
 })
 
-test('archive returns the exact adapter receipt when filing fails after cold runtime committed', async () => {
+test('archive returns the exact adapter receipt when filing fails after cold runtime committed', serial, async () => {
   const liveBefore = liveSessionsCensus()
   const previousHome = process.env.SPEXCODE_HOME
   const originalShared = codexHarness.sharedRuntimes
@@ -640,7 +642,7 @@ test('archive returns the exact adapter receipt when filing fails after cold run
   }
 })
 
-test('public close cancels a clean never-launched queue without entering the unrelated shared-runtime guard', async () => {
+test('public close cancels a clean never-launched queue without entering the unrelated shared-runtime guard', serial, async () => {
   const previousHome = process.env.SPEXCODE_HOME
   const originalShared = codexHarness.sharedRuntimes
   const originalCleanup = codexHarness.cleanupRuntime
@@ -741,7 +743,7 @@ test('public close cancels a clean never-launched queue without entering the unr
   }
 })
 
-test('launch retry log names the fast exit without guessing a daemon race', () => {
+test('launch retry log names the fast exit without guessing a daemon race', serial, () => {
   const prevHome = process.env.SPEXCODE_HOME
   const home = mkdtempSync(join(tmpdir(), 'spex-launch-log-'))
   process.env.SPEXCODE_HOME = home
@@ -766,7 +768,7 @@ test('launch retry log names the fast exit without guessing a daemon race', () =
 // @@@ the retry only covers what retrying can fix. Two launcher stubs, both exiting instantly: one printing
 // the harness's OWN settled failure (a `--resume` id claude has no conversation for), one printing nothing a
 // harness would recognise. Count the attempts each actually produces by having the stub append to a file.
-test('a launch failure the harness itself called settled is attempted exactly once', () => {
+test('a launch failure the harness itself called settled is attempted exactly once', serial, () => {
   const prevHome = process.env.SPEXCODE_HOME
   const home = mkdtempSync(join(tmpdir(), 'spex-launch-class-'))
   process.env.SPEXCODE_HOME = home
@@ -843,7 +845,7 @@ test('a launch failure the harness itself called settled is attempted exactly on
 
 // the transport's own settled failures, answered BEFORE a window is opened: a launch that cannot succeed is
 // refused once with its own code, never attempted and retried on a wall clock.
-test('launchPreflight refuses a launch that cannot succeed, naming which fact settled it', () => {
+test('launchPreflight refuses a launch that cannot succeed, naming which fact settled it', serial, () => {
   const home = mkdtempSync(join(tmpdir(), 'spex-preflight-'))
   const base: SessRec = {
     session: 'preflight-test', governed: true, worktreePath: join(home, 'gone'), branch: null, node: null,
@@ -870,7 +872,7 @@ test('launchPreflight refuses a launch that cannot succeed, naming which fact se
   }
 })
 
-test('one-shot headless launch does not retry a successful fast exit', () => {
+test('one-shot headless launch does not retry a successful fast exit', serial, () => {
   const prevHome = process.env.SPEXCODE_HOME
   const home = mkdtempSync(join(tmpdir(), 'spex-one-shot-launch-'))
   process.env.SPEXCODE_HOME = home
@@ -886,7 +888,7 @@ test('one-shot headless launch does not retry a successful fast exit', () => {
   }
 })
 
-test('a failed creation-time materialize is reported loud and stamped on the record note', () => {
+test('a failed creation-time materialize is reported loud and stamped on the record note', serial, () => {
   const prevHome = process.env.SPEXCODE_HOME
   const home = mkdtempSync(join(tmpdir(), 'spex-materialize-fail-'))
   process.env.SPEXCODE_HOME = home
@@ -918,7 +920,7 @@ test('a failed creation-time materialize is reported loud and stamped on the rec
   }
 })
 
-test('machine turn failures share one active-only error projection', () => {
+test('machine turn failures share one active-only error projection', serial, () => {
   const prevHome = process.env.SPEXCODE_HOME
   const home = mkdtempSync(join(tmpdir(), 'spex-headless-turn-state-'))
   process.env.SPEXCODE_HOME = home
@@ -981,11 +983,11 @@ test('machine turn failures share one active-only error projection', () => {
   }
 })
 
-test('turn failure observer retry is bounded exponential backoff', () => {
+test('turn failure observer retry is bounded exponential backoff', serial, () => {
   assert.deepEqual([1, 2, 3, 4, 5, 6, 20].map(turnFailureRetryDelay), [1000, 2000, 4000, 8000, 16000, 30000, 30000])
 })
 
-test('owned queues are public-authority leased and raw-state fenced from legacy drainers', () => {
+test('owned queues are public-authority leased and raw-state fenced from legacy drainers', serial, () => {
   const publicAuthority = backendLaunchAuthority({
     SPEXCODE_API_URL: 'https://operator:secret@127.0.0.1:8787/api/?token=private#fragment',
     PORT: '44725',
@@ -1015,7 +1017,7 @@ test('owned queues are public-authority leased and raw-state fenced from legacy 
   assert.equal(canDrainQueued({ status: 'queued', launchOwner: null }, 'http://127.0.0.1:8956'), true, 'legacy unowned queues remain adoptable')
 })
 
-test('a launch establishes identity: inherited session ids are stripped, this session\'s is set', () => {
+test('a launch establishes identity: inherited session ids are stripped, this session\'s is set', serial, () => {
   const prevHome = process.env.SPEXCODE_HOME
   const home = mkdtempSync(join(tmpdir(), 'spex-identity-'))
   process.env.SPEXCODE_HOME = home
@@ -1032,7 +1034,7 @@ test('a launch establishes identity: inherited session ids are stripped, this se
   }
 })
 
-test('the spawner pointer names the parent worktree and stays quiet without one', () => {
+test('the spawner pointer names the parent worktree and stays quiet without one', serial, () => {
   const parent = fromRaw({
     session_id: 'aaaaaaaa-1111-2222-3333-444444444444', governed: true,
     worktree_path: '/repo/.worktrees/parent-node-aaaa', branch: 'node/parent-node-aaaa',

--- a/spec-cli/src/sessions.test.ts
+++ b/spec-cli/src/sessions.test.ts
@@ -6,12 +6,12 @@ import { once } from 'node:events'
 import { chmodSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync, existsSync, rmSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { claudeHarness, codexHarness, codexHeadlessHarness, sessionIdentityEnvVars, stampRvSock, type SharedRuntimeProbe } from './harness.js'
 import { processStartToken } from './process-identity.js'
 import { spawnDetachedRuntime } from './runtime-ownership.js'
 import { OWNED_QUEUE_RAW_STATUS, archiveSession, backendLaunchAuthority, bootstrapMaterialize, canDrainQueued, closeSession, composeCommandPrompt, fromRaw, turnFailureNote, turnFailureRetryDelay, launchPreflight, launchScript, listSessions, markTurnFailure, markHeadlessTurnFailure, rawLifecycleStatus, resolveCommandPrompt, resumeSession, sessionCreateRequest, sessionGraph, spawnerClause, stopSession, type Session, type SessRec } from './sessions.js'
-import { runtimeRoot, sessionRecordPath, sessionArtifactPath, sessionStoreDir } from './layout.js'
+import { gitCommonDir, runtimeRoot, sessionRecordPath, sessionArtifactPath, sessionStoreDir } from './layout.js'
 import { readTimeline } from './session-timeline.js'
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
@@ -645,8 +645,7 @@ test('public close cancels a clean never-launched queue without entering the unr
   const originalShared = codexHarness.sharedRuntimes
   const originalCleanup = codexHarness.cleanupRuntime
   const home = mkdtempSync(join(tmpdir(), 'spex-queued-close-'))
-  const main = execFileSync('git', ['worktree', 'list', '--porcelain'], { encoding: 'utf8' }).split('\n')
-    .find((line) => line.startsWith('worktree '))!.slice('worktree '.length)
+  const main = dirname(gitCommonDir())
   const branches: string[] = []
   const paths: string[] = []
   process.env.SPEXCODE_HOME = home

--- a/spec-cli/src/sessions.test.ts
+++ b/spec-cli/src/sessions.test.ts
@@ -7,16 +7,20 @@ import { chmodSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFile
 import { createServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { claudeHarness, codexHarness, codexHeadlessHarness, sessionIdentityEnvVars, stampRvSock, type SharedRuntimeProbe } from './harness.js'
 import { processStartToken } from './process-identity.js'
 import { spawnDetachedRuntime } from './runtime-ownership.js'
 import { OWNED_QUEUE_RAW_STATUS, archiveSession, backendLaunchAuthority, bootstrapMaterialize, canDrainQueued, closeSession, composeCommandPrompt, fromRaw, turnFailureNote, turnFailureRetryDelay, launchPreflight, launchScript, listSessions, markTurnFailure, markHeadlessTurnFailure, rawLifecycleStatus, resolveCommandPrompt, resumeSession, sessionCreateRequest, sessionGraph, spawnerClause, stopSession, type Session, type SessRec } from './sessions.js'
 import { gitCommonDir, runtimeRoot, sessionRecordPath, sessionArtifactPath, sessionStoreDir } from './layout.js'
 import { readTimeline } from './session-timeline.js'
+import { tsxBin } from './tsx-bin.js'
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 // This file mutates process-global harness and runtime state, so its fixtures must not overlap.
 const serial = { concurrency: false } as const
+const thisTestFile = fileURLToPath(import.meta.url)
+const packageRoot = dirname(dirname(thisTestFile))
 const waitUntil = async (check: () => boolean, label: string, timeoutMs = 5000) => {
   const deadline = Date.now() + timeoutMs
   while (!check()) {
@@ -642,7 +646,17 @@ test('archive returns the exact adapter receipt when filing fails after cold run
   }
 })
 
-test('public close cancels a clean never-launched queue without entering the unrelated shared-runtime guard', serial, async () => {
+test('public close cancels a clean never-launched queue without entering the unrelated shared-runtime guard', { timeout: 150_000, ...serial }, async () => {
+  if (process.env.SPEX_QUEUE_CLOSE_FIXTURE !== '1') {
+    const fixture = spawnSync(process.execPath, [tsxBin(packageRoot), '--test', '--test-name-pattern=^public close cancels', thisTestFile], {
+      cwd: packageRoot,
+      env: { ...process.env, SPEX_QUEUE_CLOSE_FIXTURE: '1' },
+      encoding: 'utf8',
+      timeout: 120_000,
+    })
+    assert.equal(fixture.status, 0, `${fixture.stdout}\n${fixture.stderr}`)
+    return
+  }
   const previousHome = process.env.SPEXCODE_HOME
   const originalShared = codexHarness.sharedRuntimes
   const originalCleanup = codexHarness.cleanupRuntime

--- a/spec-cli/src/sessions.ts
+++ b/spec-cli/src/sessions.ts
@@ -3446,7 +3446,7 @@ async function proveQuarantineAdapter(id: string, witness: CorruptRecordQuaranti
     if (socket === 'unproven') throw new ResourceConflict(`refusing to quarantine ${id}: ${harness.id} rendezvous transport absence is unknown`)
   }
   if (witness.thread) {
-    if (!harness.quarantineOrphanThread) throw new ResourceConflict(`refusing to quarantine ${id}: ${harness.id} cannot prove and unload an exact native thread`)
+    if (!harness.quarantineOrphanThread) throw new ResourceConflict(`refusing to quarantine ${id}: ${harness.id} has no archivable native thread; omit --thread (a SpexCode session id is not an adapter thread)`)
     const native = await harness.quarantineOrphanThread(witness.thread, { excludingSessionId: id })
     if (!native.ok) throw new ResourceConflict(`refusing to quarantine ${id}: ${native.reason}`)
     return { adapter: native.audit.adapter, thread: native.audit.threadId, action: native.audit.action, compensate: native.compensate }


### PR DESCRIPTION
Spec: legacy-mark-active-compat, dispatcher-runtime, state, sessions-core, session-new-monitor-hint, cli-surface

## Root cause

The deployed legacy mark-active hook edited session.json with sed and documented an unenforced assumption that notes never contain a double quote. A quoted note therefore produced invalid JSON. The old reader then hid that existing row as if it did not exist, which removed every truthful lifecycle declaration path while the Stop hook still required one.

## Fix

0.5.9 recognizes only the exact legacy core mark-active bytes at the standard project-hook path and dispatches that call to the packaged structured-writer template. It does not write the project hook, materialize files, or alter a byte-different customization. This gives frozen worktrees a zero-tracked-byte activation path. The regression test first executes the old fixture directly and proves that a quoted note is invalid JSON; the same fixture through dispatcher is parseable and preserves the note.

The existing corrupt projection distinguishes a present unreadable record from an absent id: corrupt rows remain visible with their parse error, while unknown ids remain missing. The PR also makes quarantine help, usage, and Claude refusal explicit: --thread is an adapter-native conversation id, never the SpexCode session id; omit it for Claude.

## Corrupt recovery

For a row with no live leaf/tmux/worktree/branch, quarantine moves only the opaque session.json to an auditable bundle, with exact bytes and observed proof. It sends no OS signal and is reversible with --restore. A live or ambiguous native process remains a loud refusal; this PR deliberately does not add a force-kill path that could terminate an unproven process.

## Dispatch scope

BUG 2 is not claimed as fixed by this P0 backport. Its durable delivery change is 1ea0d62a, which is not contained in the released 0.5.8 baseline targeted here; it needs its own upstream integration/release review.

## Verification

- hook-dispatch.test.ts: 16/16 pass
- session-record-integrity.test.ts: 1/1 pass
- session-help-cli.test.ts: 2/2 pass
- npm run lint and spex spec lint: 0 errors
- npm pack --dry-run: 0.5.9 package includes fixture, dispatcher, and template
